### PR TITLE
Correctly calculate bandwidth occupied by queues

### DIFF
--- a/neutron_qos/db/qos/qos_db.py
+++ b/neutron_qos/db/qos/qos_db.py
@@ -194,7 +194,8 @@ class QosDbMixin(ext_qos.QosPluginBase, base_db.CommonDbMixin):
         return self._fields(res, fields)
 
     def _aggregate_rate_of_qos(self, qos):
-        return reduce(lambda x, y: x + y, [q.rate for q in qos.queues])
+        return reduce(lambda x, y: x + y,
+                      [q.rate for q in qos.queues if q.parent_queue is None])
 
     def _check_qos_rate(self, qos, delta, maximum=None):
         if maximum is None:


### PR DESCRIPTION
Queues which are not directly under the qos should be filter out.

Fixes: redmine #5965

Signed-off-by: huntxu mhuntxu@gmail.com
