### PR TITLE
Fix the last qos in a namespace cannot be deleted

### DIFF
--- a/neutron_qos/services/qos/agents/tc_manager.py
+++ b/neutron_qos/services/qos/agents/tc_manager.py
@@ -22,8 +22,6 @@ from neutron.services.qos.common import htb
 
 utils.synchronized('tc', external=True)
 
-ROUTER_NS_PREFIX = 'qrouter-'
-
 
 class TcManager(object):
     """Wrapper for tc."""

--- a/neutron_qos/services/qos/common/htb.py
+++ b/neutron_qos/services/qos/common/htb.py
@@ -388,7 +388,7 @@ class RTNetLink(netns.NetNSSwitcher):
 def get_qos_conf_scheme(router_id=None, filter_by_name=None):
     namespace = None
     if router_id:
-        namespace = 'qrouter-' + router_id
+        namespace = netns.ROUTER_NS_PREFIX + router_id
 
     ret = {}
 


### PR DESCRIPTION
If the last qos in a namespace is deleted, server will not send any
information about that to the agent. Thus the agent should keep which
namespaces it is hosting to be able to delete qdiscs which should be
removed.

Fixes: redmine #8954

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>