### PR TITLE
agent_sync: filter out not-ready fip port targets

### DIFF
--- a/neutron_qos/db/qos/qos_db.py
+++ b/neutron_qos/db/qos/qos_db.py
@@ -827,6 +827,8 @@ class QosPluginRpcDbMixin(object):
                             context, qos.port.device_id)
                     except ext_l3.FloatingIPNotFound:
                         continue
+                    if fip['router_id'] is None:
+                        continue
                     namespace = 'qrouter-' + fip['router_id']
                 else:
                     namespace = '_root'


### PR DESCRIPTION
When a FIP is not associated with a fixed IP, its port is not configured
on the hosts, and its router_id is None. So no QoS should be applied on
the target port.

Fixes: redmine #10738

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>